### PR TITLE
Update bonfire to enable telementry

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "==3.0.2"
-crc-bonfire = "*"
+crc-bonfire = "==5.7.0"
 flask-cors = "==4.0.0"
 flask-socketio = "==5.3.6"
 gunicorn = "==21.2.0"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "==3.0.2"
-crc-bonfire = "==5.6.0"
+crc-bonfire = "*"
 flask-cors = "==4.0.0"
 flask-socketio = "==5.3.6"
 gunicorn = "==21.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4a3554a2809260bcaf0aebf44d47104153fbed45f2db1748e7659e0b1b1dd55"
+            "sha256": "dced73fee8d23f91126c8432e9a51b375be75d25535547f650fa4523fb70b2d7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -191,12 +191,12 @@
         },
         "crc-bonfire": {
             "hashes": [
-                "sha256:2a799f2181940e9a118131d94beb4909b86de41edb6fbb53fb7e8bb01b47c8a7",
-                "sha256:8ff67ba5399c0c7ee6a3ac05f8e05336e043df4da6e8e1c855583c27e24a66ee"
+                "sha256:d9848acc005067613c6e8df0703aa1b14572619986dbed61df6858abc9e3d98f",
+                "sha256:dd6281ceb82fc6a563d87a2bd62e6c967d66d6e625cbf5026ff942c18f479411"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==5.6.0"
+            "version": "==5.7.0"
         },
         "flask": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dced73fee8d23f91126c8432e9a51b375be75d25535547f650fa4523fb70b2d7"
+            "sha256": "dd9cfdd40b35d193099d0eacf507cb2dbc05ebbebc36b23fa23641537d87606e"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -70,6 +70,8 @@ objects:
               secretKeyRef:
                 name: firelink-graphql-creds
                 key: APP_INTERFACE_USERNAME
+          - name: CLIENT_ID
+            value: firelink
       webServices:
         public:
           enabled: True

--- a/firelink/Namespace.py
+++ b/firelink/Namespace.py
@@ -88,7 +88,7 @@ class Namespace:
     def describe(self, namespace):
         self.helpers.route_guard()
         try:
-            descriptionText = bonfire.describe_namespace(namespace)
+            descriptionText = bonfire.describe_namespace(namespace, "string")
             response = {"completed": True, "message": self. _parse_description_to_json(descriptionText)}
         except Exception as e:
             response = {"completed": False, "message": "ERROR: " + str(e)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ certifi==2024.2.2
 chardet==3.0.4
 charset-normalizer==3.3.2
 click==8.1.7
-crc-bonfire==5.6.0
+crc-bonfire==5.7.0
 Flask==3.0.2
 Flask-Caching==2.1.0
 Flask-Cors==4.0.0


### PR DESCRIPTION
This patch updates bonfire to take advantage of the new telemetry client ID. I also had to update one method call because the signature changed.

We still don't have tests in CI but I did run tests and they pass

```
(firelink-backend) ~/Development/firelink-backend[update-bonfire-to-enable-telementry L|⚑1]> make test
python -m pytest tests/
========================================== test session starts ==========================================
platform darwin -- Python 3.11.7, pytest-8.0.0, pluggy-1.4.0
rootdir: /Users/adam/Development/firelink-backend
configfile: pytest.ini
collected 10 items                                                                                      

tests/test_apps.py ...                                                                                                           [ 30%]
tests/test_namespaces.py .......                                                                                                 [100%]

==================================================== 10 passed in 462.26s (0:07:42) ====================================================
```