### PR TITLE
Add the elastic telemetry 

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -78,7 +78,7 @@ objects:
             valueFrom:
               secretKeyRef:
                 name: elastcisearch
-                key: api-ley
+                key: api-key
           - name: ELASTICSEARCH_HOST
             valueFrom:
               secretKeyRef:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -72,6 +72,8 @@ objects:
                 key: APP_INTERFACE_USERNAME
           - name: CLIENT_ID
             value: firelink
+          - name: TELEMETRY_ENABLED
+            value: "True"
       webServices:
         public:
           enabled: True

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -74,6 +74,16 @@ objects:
             value: firelink
           - name: TELEMETRY_ENABLED
             value: "True"
+          - name: ELASTICSEARCH_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: elastcisearch
+                key: api-ley
+          - name: ELASTICSEARCH_HOST
+            valueFrom:
+              secretKeyRef:
+                name: elastcisearch
+                key: host
       webServices:
         public:
           enabled: True


### PR DESCRIPTION
This patch adds the deploy telemetry calls from Bonfire. The feature is locked behind a new ENABLE_TELEMETRY env var that is in the clowd app template.