### PR TITLE
Add renovate config file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		":disableMajorUpdates",
+		"github>konflux-ci/mintmaker-presets:cve-automerge-all",
+		"github>konflux-ci/mintmaker-presets:group-python-requirements"
+	],
+	"dockerfile": {
+		"managerFilePatterns": [
+			"/Dockerfile$/"
+		]
+	},
+	"packageRules": [
+		{
+			"matchDatasources": [ "docker" ],
+			"matchPackageNames": [
+				"registry.access.redhat.com/ubi9/python-311"
+			],
+			"versioning": "redhat"
+		}
+	]
+}


### PR DESCRIPTION
Add renovate config file:

- group changes to requirements.txt
- set automerge config for CVEs
- disable major updates for packages
- set tag rules for redhat images